### PR TITLE
Accept file-based reforms for elasticity of GDP

### DIFF
--- a/dropq/__init__.py
+++ b/dropq/__init__.py
@@ -2,7 +2,7 @@ from .dropq import (run_models, groupby_means_and_comparisons, run_nth_year,
                     only_growth_assumptions, only_behavior_assumptions,
                     only_reform_mods, example_data, format_macro_results,
                     run_nth_year_mtr_calc, run_gdp_elast_models,
-                    get_unknown_parameters)
+                    get_unknown_parameters, elasticity_of_gdp_year_n)
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/dropq/dropq.py
+++ b/dropq/dropq.py
@@ -112,14 +112,17 @@ def elasticity_of_gdp_year_n(user_mods, year_n):
     Extract elasticity of GDP parameter for the proper year
     """
     allkeys = sorted(user_mods.keys())
-    reforms = user_mods[allkeys[0]]
-    ELASTICITY_LIST = reforms.get("elastic_gdp", None)
-    if not ELASTICITY_LIST:
+    all_elast_params = []
+    for year in user_mods:
+        reform = user_mods[year]
+        all_elast_params += reform.get("elastic_gdp", [0.0])
+
+    if not all_elast_params:
         raise ValueError("user_mods should specify elastic_gdp")
-    if year_n >= len(ELASTICITY_LIST):
-        return ELASTICITY_LIST[-1]
+    if year_n >= len(all_elast_params):
+        return all_elast_params[-1]
     else:
-        return ELASTICITY_LIST[year_n]
+        return all_elast_params[year_n]
 
 
 def random_seed_from_plan(calc):
@@ -300,7 +303,6 @@ def run_nth_year_mtr_calc(year_n, start_year, tax_dta, user_mods="", return_json
     assert year_n > 0
 
     elasticity_gdp = elasticity_of_gdp_year_n(user_mods, year_n)
-
 
     #########################################################################
     #   Create Calculators and Masks

--- a/dropq/tests/test_dropq.py
+++ b/dropq/tests/test_dropq.py
@@ -143,3 +143,21 @@ def test_format_macro_results():
                          '0.002', '0.002', '0.002', '0.002', '0.003', '0.002']}
 
     assert diff_table == x
+
+
+def test_elasticity_of_gdp_year_n():
+
+    x = {2016: {'_PT_rt7': [0.41], 'elastic_gdp': [0.14, 0.15, 0.16], '_II_rt7': [0.41]}}
+
+    assert elasticity_of_gdp_year_n(x, 0) == 0.14
+    assert elasticity_of_gdp_year_n(x, 1) == 0.15
+    assert elasticity_of_gdp_year_n(x, 2) == 0.16
+    assert elasticity_of_gdp_year_n(x, 3) == 0.16
+
+def test_elasticity_of_gdp_year_n_multiple_year_keys():
+
+    x = {2016: {'_PT_rt7': [0.41], '_II_rt7': [0.41]}, 2017: {'elastic_gdp': [0.15]} }
+    assert elasticity_of_gdp_year_n(x, 0) == 0.
+    assert elasticity_of_gdp_year_n(x, 1) == 0.15
+    assert elasticity_of_gdp_year_n(x, 2) == 0.15
+    assert elasticity_of_gdp_year_n(x, 3) == 0.15


### PR DESCRIPTION
- File-based reforms could generate reform dictionaries of the style:
  
  {year: {reform}, year+1: {reform}... }
  
  instead of the style generated by the web-based TaxBrain input page
  
  {year: {reform....}}
  
  where reforms in later years are sequential values of the particular
  reform value.
  
  add test to still grab the proper elasticity of GDP for year_n from
  the reform
